### PR TITLE
Timestamps, new version 0.3.1

### DIFF
--- a/.github/workflows/python-package-test.yml
+++ b/.github/workflows/python-package-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/python-package-test.yml
+++ b/.github/workflows/python-package-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For a system-wide and global installation, simply do:
 
 If you prefer an installation in a virtual environment, create one first:
 
-    virtualenv -p python3.10 speechcatcher_env
+    virtualenv -p python3.11 speechcatcher_env
 
 Note, if you get "-bash: virtualenv: command not found", install virtualenv through pip:  
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ All required model files are downloaded automatically and placed into a ".cache"
 
 ## Use speechcatcher in your Python code
 
-To use speechcatcher in your Python script, you need to import the speechcatcher package and use the recognize function. Here is a complete example, that reads a 16kHz mono wav and outputs the recognized text:
+To use speechcatcher in your Python script, you need to import the speechcatcher package and use the recognize function in a '__main__' guarded block. Here is a complete example, that reads a 16kHz mono wav and outputs the recognized text:
 
     from speechcatcher import speechcatcher
     import numpy as np
     from scipy.io import wavfile
     
+    # you need to run speechcatcher in a '__main__' guarded block:
     if __name__ == '__main__':
         short_tag = 'de_streaming_transformer_xl'
         speech2text = speechcatcher.load_model(speechcatcher.tags[short_tag])
@@ -70,9 +71,20 @@ To use speechcatcher in your Python script, you need to import the speechcatcher
         print(f"Audio Shape: {audio_data.shape}")
     
         # speech is a numpy array of dtype='np.int16' (16bit audio with 16kHz sampling rate)
-        complete_text, paragraphs, paragraphs_tokens, paragraph_hyps, segments_start_end_in_seconds = speechcatcher.recognize(speech2text, speech, rate, quiet=True, progress=False)
+        complete_text, paragraphs = speechcatcher.recognize(speech2text, speech, rate, quiet=True, progress=False)
     
+        # complete_text is a string with the complete decoded text
         print(complete_text)
+        
+        # -> Faust. Eine Tragödie von Johann Wolfgang von Goethe. Zueignung. Ihr naht euch wieder, schwankende Gestalten...
+
+        # paragraphs contains a list of paragraphs with additional information, such as start and end position,
+        # token and token_timestamps (upper bound, in seconds)
+        print(paragraphs)
+        
+        # -> [{'start': 0, 'end': 44.51, 'text': 'Faust. Eine Tragödie von Johann Wolfgang von Goethe. Zueignung. Ihr naht euch wieder, schwankende Gestalten...', 'tokens': ['▁F', 'aus', 't', '.', '▁Ein', 'e', '▁Tra', 'g', 'ö', 'di', 'e', '▁von', '▁Jo', 'ha', 'n', 'n', '▁Wo', 'l', 'f', 'gang', '▁von', '▁G', 'o', 'et', 'he', '.', '▁Zu', 'e', 'ig', 'n', 'ung', '.', '▁I', 'hr', '▁', 'na', 'ht', '▁euch', '▁wieder', ',', '▁sch', 'wa', 'n', 'ken', 'de', '▁Ge', 'st', 'al', 'ten', '.', ...
+'token_timestamps': [1.666, 2.333, 2.333, 3.0, 3.0, 3.0, 3.0, 3.0, 3.666, 4.333, 4.333, 4.333, 5.0, 5.0, 5.0, 5.0, 5.0, 5.666, 5.666, 5.666, 6.333, 6.333, 6.333, 7.0, 7.666, 7.666, 7.666, 7.666, 8.333, 9.666, 9.666, 9.666, 9.666, 9.666, 9.666, 10.333, 10.333, 11.0, 11.666, 11.666, 11.666, 11.666, 11.666, 12.333, 12.333, 12.333, 13.0, 13.666, 14.333, 14.333, 14.333, 14.333, 14.333, 14.333, 14.333, ... ]}, ... ]
+
 
 ## Available models
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch
 torchaudio
 ffmpeg-python
-espnet @ git+https://github.com/speechcatcher-asr/espnet
+espnet_streaming_decoder @ git+https://github.com/speechcatcher-asr/espnet_streaming_decoder
 espnet_model_zoo
 soundfile
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ torch
 torchaudio
 ffmpeg-python
 espnet_streaming_decoder @ git+https://github.com/speechcatcher-asr/espnet_streaming_decoder
-espnet_model_zoo
+espnet_model_zoo @ git+https://github.com/speechcatcher-asr/espnet_model_zoo
 soundfile
 six
 pyaudio

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='speechcatcher',
-    version='0.2.0',
+    version='0.3.0',
     author="Benjamin Milde",
     author_email="bmilde@users.noreply.github.com",
     description="Speechcatcher is an open source toolbox for transcribing speech from media files (audio/video).",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='speechcatcher',
-    version='0.3.0',
+    version='0.3.1',
     author="Benjamin Milde",
     author_email="bmilde@users.noreply.github.com",
     description="Speechcatcher is an open source toolbox for transcribing speech from media files (audio/video).",

--- a/speechcatcher/speechcatcher.py
+++ b/speechcatcher/speechcatcher.py
@@ -286,6 +286,7 @@ def recognize(speech2text, raw_speech_data, rate, chunk_length=8192, num_process
     if status:
         t = threading.Thread(target=status_output, args=(q, max_i, status))
         t.start()
+        progress=True
 
     with ProcessPoolExecutor(max_workers=num_processes, initializer=init_pool_processes,
                              initargs=(q, speech2text, speech)) as executor:

--- a/speechcatcher/speechcatcher.py
+++ b/speechcatcher/speechcatcher.py
@@ -112,11 +112,11 @@ def status_output(q, max_i, status):
     output_every = 10
     while progress_i < max_i:
         q.get(block=True)
-        progress_i += 1
         percentage = (progress_i / max_i) * 100.0
         formatted_output_str = f"Transcribing... {percentage:.{precision}f}%"
         if progress_i % output_every == 0:
             status.publish_status(formatted_output_str)
+        progress_i += 1
 
 # Output current hypothesis on the fly. Note that .
 def progress_output(text, prev_lines=0):

--- a/speechcatcher/speechcatcher.py
+++ b/speechcatcher/speechcatcher.py
@@ -113,7 +113,7 @@ def status_output(q, max_i, status):
     while progress_i < max_i:
         q.get(block=True)
         percentage = (progress_i / max_i) * 100.0
-        formatted_output_str = f"Transcribing... {percentage:.{precision}f}%"
+        formatted_output_str = f"Decoding progress: {percentage:.{precision}f}%"
         if progress_i % output_every == 0:
             status.publish_status(formatted_output_str)
         progress_i += 1

--- a/speechcatcher/speechcatcher.py
+++ b/speechcatcher/speechcatcher.py
@@ -79,6 +79,17 @@ def load_model(tag, device='cpu', beam_size=5, quiet=False, cache_dir='~/.cache/
                                 )
 
 
+# Convert input file to 16 kHz mono, use stdout to capture the output in-memory
+def convert_inputfile_inmemory(filename):
+    out, _ = (
+        ffmpeg.input(filename)
+            .output('pipe:', format='wav', acodec='pcm_s16le', ac=1, ar='16k')
+            .run(quiet=True, overwrite_output=True)
+    )
+
+    return out
+
+
 # Convert input file to 16 kHz mono
 def convert_inputfile(filename, outfile_wav):
     return (

--- a/speechcatcher/speechcatcher.py
+++ b/speechcatcher/speechcatcher.py
@@ -112,11 +112,11 @@ def status_output(q, max_i, status):
     output_every = 10
     while progress_i < max_i:
         q.get(block=True)
+        progress_i += 1
         percentage = (progress_i / max_i) * 100.0
         formatted_output_str = f"Decoding progress: {percentage:.{precision}f}%"
         if progress_i % output_every == 0:
             status.publish_status(formatted_output_str)
-        progress_i += 1
 
 # Output current hypothesis on the fly. Note that .
 def progress_output(text, prev_lines=0):

--- a/speechcatcher/speechcatcher.py
+++ b/speechcatcher/speechcatcher.py
@@ -625,6 +625,10 @@ def main():
     if args.num_processes != -1:
         num_processes = args.num_processes
 
+    # do not use multiprocessing on GPU
+    if args.device.lower() != 'cpu':
+        num_processes = 1 
+
     if args.model not in tags:
         print(f'Model {args.model} is not a valid model!')
         print('Options are:', ', '.join(tags.keys()))

--- a/speechcatcher/speechcatcher.py
+++ b/speechcatcher/speechcatcher.py
@@ -283,7 +283,7 @@ def recognize(speech2text, raw_speech_data, rate, chunk_length=8192, num_process
         t.start()
 
     # Custom status object that you can use as a callback. Uses the function publish_status(msg: str) on the object.
-    if status and not progress:
+    if status:
         t = threading.Thread(target=status_output, args=(q, max_i, status))
         t.start()
 


### PR DESCRIPTION
New features:

Support for timestamps on the token level. 

Using espnet_streaming_decoder instead of espnet, to make dependencies leaner and to enable token timestamps. Speechcatcher does not require a full Espnet installation anymore.

Using a forked espnet_model_zoo, so that models downloads are only checked if a local cache copy isn't available.